### PR TITLE
Fix broken link 'Build it yourself'

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
                                         <p><a href="https://pypi.python.org/pypi/pext/"><span class="fas fa-archive fa-lg"></span> PyPI</a></p>
                                         <h4>Here be dragons</h4>
                                         <p><a href="https://github.com/Pext/Pext/releases/tag/continuous"><span class="fas fa-archive fa-lg"></span> Test versions</a></p>
-                                        <p><a href="https://github.com/Pext/Pext/blob/master/INSTALL_FROM_SOURCE.md"><span class="fas fa-archive fa-lg"></span> Build it yourself</a></p>
+                                        <p><a href="https://pext.readthedocs.io/en/latest/compiling.html#gnu-linux"><span class="fas fa-archive fa-lg"></span> Build it yourself</a></p>
                                     </div>
                                     <div class="tab-pane fade" id="macos" role="tabpanel" aria-labelledby="macos">
                                         <h2>Recommended</h2>
@@ -106,14 +106,14 @@
                                         <h4>Here be dragons</h4>
                                         <p><a href="https://github.com/Pext/Pext/releases/tag/continuous"><span class="fas fa-archive fa-lg"></span> Test versions</a></p>
                                         <p><a href="#" onClick="window.alert('If you have Homebrew installed, run the following commands: brew tap homebrew/cask-versions && brew cask install pext-nightly')"><span class="fas fa-archive fa-lg"></span> Homebrew Cask Nightly</a></p>
-                                        <p><a href="https://github.com/Pext/Pext/blob/master/INSTALL_FROM_SOURCE.md"><span class="fas fa-archive fa-lg"></span> Build it yourself</a></p>
+                                        <p><a href="https://pext.readthedocs.io/en/latest/compiling.html#macos"><span class="fas fa-archive fa-lg"></span> Build it yourself</a></p>
                                     </div>
                                     <div class="tab-pane fade" id="windows" role="tabpanel" aria-labelledby="windows">
                                         <h2>Recommended</h2>
                                         <p><a href="https://github.com/Pext/Pext/releases/download/v0.25/Pext.exe"><span class="fas fa-archive fa-lg"></span> Pext Installer</a></p>
                                         <h4>Here be dragons</h4>
                                         <p><a href="https://github.com/Pext/Pext/releases/tag/continuous"><span class="fas fa-archive fa-lg"></span> Test versions</a></p>
-                                        <p><a href="https://github.com/Pext/Pext/blob/master/INSTALL_FROM_SOURCE.md"><span class="fas fa-archive fa-lg"></span> Build it yourself</a></p>
+                                        <p><a href="https://pext.readthedocs.io/en/latest/compiling.html#windows"><span class="fas fa-archive fa-lg"></span> Build it yourself</a></p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
'Build it yourself' links for each OS were broken. 
Now, all links are pointing to the new docs page, each pointing to the corresponding its OS anchor.